### PR TITLE
improve run.py's ability to be imported as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ### Run
 ```
-docker run -it -v $(pwd):/data/ jpfeil/typhon:0.1.0 --RSEM typhon/test/rsem_genes.results --diagnosis MYCN-NA-Neuroblastoma
+docker run --rm -v $(pwd):/data/ jpfeil/typhon:0.1.0 --RSEM /opt/typhon/test/rsem_genes.results --diagnosis MYCN-NA-Neuroblastoma
 ```

--- a/typhon/run.py
+++ b/typhon/run.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python2.7
 
-import sys
-sys.path.append('/opt/hydra/')
-
 import argparse
 import bnpy
 import logging
@@ -10,23 +7,60 @@ import numpy as np
 import os
 import pandas as pd
 import shutil
+import errno
 
-import library.analysis as hydra
-from library.utils import mkdir_p
-from library.fit import get_assignments
+def ens_to_hugo(ens_to_hugo_filepath='/opt/typhon/data/EnsGeneID_Hugo_Observed_Conversions.txt'):
+    ens_to_hugo_dict = {}
+    with open(ens_to_hugo_filepath) as f:
+        header = next(f)
+        for line in f:
+            hugo, ens = line.strip().split('\t')
+            ens_to_hugo_dict[ens] = hugo
+    return ens_to_hugo_dict
 
+# mkdir_p from hydra library/utils.py
+def mkdir_p(path):
+    """
+    https://stackoverflow.com/questions/600268/mkdir-p-functionality-in-python
+    :param path:
+    :return:
+    """
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
-ens_to_hugo = {}
-with open('/opt/typhon/data/EnsGeneID_Hugo_Observed_Conversions.txt') as f:
-    header = next(f)
-    for line in f:
-        hugo, ens = line.strip().split('\t')
-        ens_to_hugo[ens] = hugo
+# get_assignments from hydra library/fit.py
+def get_assignments(model, data):
+    """
+    Takes model and data and classifies samples
+    Will label samples with NaN if they do not
+    fit in any of the model components
+    :param model:
+    :param data:
+    :return:
+    """
+    unclass = 1 - np.sum(model.allocModel.get_active_comp_probs())
+    # Get the sample assignments
+    LP = model.calc_local_params(data)
+    asnmts = []
+    for row in range(LP['resp'].shape[0]):
+        _max = np.max(LP['resp'][row, :])
+        if _max < unclass:
+            asnmts.append(np.nan)
 
+        else:
+            _arg = np.argmax(LP['resp'][row, :])
+            asnmts.append(_arg)
 
-def fit_models(data, diagnosis, output_dir):
+    return asnmts
+
+def fit_models(data, diagnosis, output_dir, models_root_dir='/opt/typhon/models/'):
     logger = logging.getLogger('root')
-    models_pth = os.path.join('/opt/typhon/models/', diagnosis)
+    models_pth = os.path.join(models_root_dir, diagnosis)
 
     # Load Enrichment Analysis
     for model in os.listdir(models_pth):
@@ -96,7 +130,7 @@ def main():
 
     data = pd.read_csv(args.RSEM, sep='\t')
 
-    data['hugo'] = data['gene_id'].map(ens_to_hugo)
+    data['hugo'] = data['gene_id'].map(ens_to_hugo())
     tpm = data.reindex(['hugo', 'TPM'], axis=1).groupby('hugo').sum()
     exp = np.log2(tpm + 1)
 


### PR DESCRIPTION
in service of integration of typhon into CARE, some changes to run.py
so it can be imported more easily from other scripts.
(also update to README to fix example command line)

- ens_to_hugo only required when running from main()

- remove dependency on hydra; two functions are copied over from hydra
(mkdir_p, get_assignments)

- add optional argument to fit_models of where to find the models